### PR TITLE
Added X-Ray active tracing and fixed an issue with names API endpoint

### DIFF
--- a/apps/lambda/sam.yaml
+++ b/apps/lambda/sam.yaml
@@ -2,6 +2,9 @@ AWSTemplateFormatVersion: '2010-09-09'
 Transform: 'AWS::Serverless-2016-10-31'
 Description: >-
   Amazon API Gateway.
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
 Resources:
   GreetingFunction:
     Type: 'AWS::Serverless::Function'
@@ -13,6 +16,7 @@ Resources:
         Amazon API Gateway.
       MemorySize: 1024
       Timeout: 20
+      Tracing: Active
       Events:
         greet:
           Type: Api
@@ -49,6 +53,7 @@ Resources:
         Amazon API Gateway.
       MemorySize: 1024
       Timeout: 20
+      Tracing: Active
       Events:
         findname:
           Type: Api
@@ -122,6 +127,7 @@ Resources:
         Amazon API Gateway.
       MemorySize: 1024
       Timeout: 20
+      Tracing: Active
       Environment:
         Variables:
           GREETING_SERVICE_HOST: !Sub "${GreetingApi}.execute-api.${AWS::Region}.amazonaws.com"
@@ -130,7 +136,7 @@ Resources:
           GREETING_SERVICE_SCHEME: "https"
           NAME_SERVICE_HOST: !Sub "${NamesApi}.execute-api.${AWS::Region}.amazonaws.com"
           NAME_SERVICE_PORT: "443"
-          NAME_SERVICE_PATH: "/prod/resources/names/1"
+          NAME_SERVICE_PATH: "/prod/resources/names"
           NAME_SERVICE_SCHEME: "https"
       Events:
         WebAppRoot:

--- a/services/webapp/src/main/java/org/aws/samples/compute/webapp/WebappController.java
+++ b/services/webapp/src/main/java/org/aws/samples/compute/webapp/WebappController.java
@@ -28,7 +28,7 @@ public class WebappController {
     public String getMessage(@Context UriInfo uri, @PathParam("id") String id) {
         String greetingEndpoint = getEndpoint("GREETING", uri.getRequestUri().getScheme(), null);
         logger.info("ID Query is: " + id);
-        String pathQuery = (id.equals("")) ? null : ("/" + id);
+        String pathQuery = (id.equals("")) ? "/1" : ("/" + id);
         String nameEndpoint = getEndpoint("NAME", uri.getRequestUri().getScheme(), pathQuery);
 
         Segment segment = AWSXRay.getCurrentSegment();


### PR DESCRIPTION
*Issue #, if available:* #151 

*Description of changes:* Removed default path from the endpoint environment variable from the SAM template and changed the default path for the webapp -> names to `/1`.

As a bonus I've also enabled X-Ray active tracing in all functions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
