### PR TITLE
Upgrade deprecated runtime nodejs6.10

### DIFF
--- a/apps/lambda/greeting-sam.yaml
+++ b/apps/lambda/greeting-sam.yaml
@@ -83,7 +83,7 @@ Resources:
     Properties:
       CodeUri: ./hooks/
       Handler: preTrafficHook.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       FunctionName: CodeDeployHook_gretting_preTrafficHook
       DeploymentPreference:
         Enabled: false  
@@ -105,7 +105,7 @@ Resources:
     Properties:
       CodeUri: ./hooks/
       Handler: preTrafficHook.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       FunctionName: CodeDeployHook_gretting_postTrafficHook
       DeploymentPreference:
         Enabled: false  


### PR DESCRIPTION
CloudFormation templates in aws-microservices-deploy-options have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs6.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.